### PR TITLE
Selenium template fix

### DIFF
--- a/armtemplates/selenium/azuredeploy.json
+++ b/armtemplates/selenium/azuredeploy.json
@@ -88,7 +88,7 @@
                         "value": "[resourceGroup().location]"
                     },
                     "fileUris": {
-                        "value": "https://raw.githubusercontent.com/Microsoft/VSTS-DevOps-Labs/master/selenium/arm%20template/chrome_%20firefox_VSTSagent_IIS.ps1"
+                        "value": "https://raw.githubusercontent.com/Microsoft/VSTS-DevOps-Labs/master/armtemplates/selenium/chrome_%20firefox_VSTSagent_IIS.ps1"
                     }
                 }
             },

--- a/armtemplates/selenium/chrome_ firefox_VSTSagent_IIS.ps1
+++ b/armtemplates/selenium/chrome_ firefox_VSTSagent_IIS.ps1
@@ -47,7 +47,7 @@ Start-Sleep -s 35
 rm -Force $workdir\firefox*
 
 #copy geckodriver
-Invoke-WebRequest https://github.com/Microsoft/VSTS-DevOps-Labs/blob/master/selenium/arm%20template/geckodriver.exe?raw=true -OutFile "C:\Program Files\Mozilla Firefox\geckodriver.exe"
+Invoke-WebRequest https://github.com/Microsoft/VSTS-DevOps-Labs/tree/master/armtemplates/selenium/geckodriver.exe?raw=true -OutFile "C:\Program Files\Mozilla Firefox\geckodriver.exe"
 
 #Downlaod and extract VSTS windows agent
 mkdir C:\VSTSwinAgent ;


### PR DESCRIPTION
Fixed URLs that references artifacts in the repository. After repository structure refactoring these URLs weren't updated. When we try to deploy this template we get a 404 file not found in the CustomScript step.

![image](https://user-images.githubusercontent.com/13902880/36920361-451910d6-1e3f-11e8-8a10-2092c4c764c9.png)
